### PR TITLE
Hotfix - Fixed issue with Parameters in Production

### DIFF
--- a/app/components/Config/index.js
+++ b/app/components/Config/index.js
@@ -1,9 +1,8 @@
 import React, { Component } from 'react';
-import jetpack from 'fs-jetpack';
 import os from 'os';
 
 import { readerMapType, eventsType } from '../../actions/config';
-import { CONFIG_PATH } from '../Home';
+import log from '../../lib/logger';
 
 import SyncReaders from '../../containers/AppSyncReaders';
 
@@ -128,8 +127,7 @@ class Configuration extends Component {
     this.props.setReaderMap(readerMap);
     this.setState({ readerMap });
 
-    jetpack.write(
-      CONFIG_PATH,
+    log.file('config.json',
       {
         runScoreAddress,
         runScorePort,

--- a/app/components/Home/index.js
+++ b/app/components/Home/index.js
@@ -8,9 +8,7 @@ import TimerPanel from '../../containers/TimerPanel';
 import Toolbar from '../../containers/AppToolbar';
 
 import { relay } from '../../index';
-import { LOGS_PATH } from '../../server';
-
-export const CONFIG_PATH = `${LOGS_PATH}/config.json`;
+import log from '../../lib/logger';
 
 export default class Home extends Component {
   props: {
@@ -19,7 +17,7 @@ export default class Home extends Component {
 
   // Load the configuration files
   componentWillMount() {
-    const config = jetpack.read(CONFIG_PATH, 'json');
+    const config = jetpack.read(log.configPath(), 'json');
     if (config) {
       this.props.loadConfigurations({
         ...config,
@@ -27,7 +25,7 @@ export default class Home extends Component {
         listenPort: Number(config.listenPort) || 0
       });
     } else {
-      jetpack.file(CONFIG_PATH, { content: {} });
+      jetpack.file(log.configPath(), { content: {} });
     }
 
     relay.start();

--- a/app/constants.js
+++ b/app/constants.js
@@ -1,3 +1,6 @@
 export const APP_HEIGHT = 215;
 export const APP_EXTENDED_HEIGHT = 500;
 export const APP_WIDTH = 400;
+
+export const LLRP_TAG_REGEX = /(00f0000c00f100080010)((\d){4})/;
+export const MAX_CONNECT_ATTEMPTS = 5;

--- a/app/lib/LLRP/messages.js
+++ b/app/lib/LLRP/messages.js
@@ -1,6 +1,6 @@
 import * as constants from './messageConstants';
-import * as parameters from './parameters';
-import * as properties from './properties';
+import Parameters from './parameters';
+import Properties from './properties';
 import { createLLRPMessage } from './encode';
 
 export const addROSpec = () => (
@@ -8,7 +8,7 @@ export const addROSpec = () => (
     id: 0x55,
     type: constants.ADD_ROSPEC,
     args: [
-      parameters.ROSpec({
+      Parameters.ROSpec({
         ROSpecID: '1',
         ROSpecPriority: '0',
         ROSpecCurrentState: '0',
@@ -57,7 +57,7 @@ export const enableROSpec = () => (
   createLLRPMessage({
     id: 0x66,
     type: constants.ENABLE_ROSPEC,
-    args: [properties.ROSpecID('1')]
+    args: [Properties.ROSpecID('1')]
   })
 );
 
@@ -65,7 +65,7 @@ export const startROSpec = () => (
   createLLRPMessage({
     id: 0x77,
     type: constants.START_ROSPEC,
-    args: [properties.ROSpecID('1')]
+    args: [Properties.ROSpecID('1')]
   })
 );
 
@@ -73,7 +73,7 @@ export const deleteROSpec = () => (
   createLLRPMessage({
     id: 0x771,
     type: constants.DELETE_ROSPEC,
-    args: [properties.ROSpecID('1')]
+    args: [Properties.ROSpecID('1')]
   })
 );
 
@@ -82,10 +82,10 @@ export const getReaderConfig = () => (
     id: 0x88,
     type: constants.GET_READER_CONFIG,
     args: [
-      properties.AntennaID('0'),
-      properties.RequestedData('0'),
-      properties.GPIPortNumber('0'),
-      properties.GPOPortNumber('0')
+      Properties.AntennaID('0'),
+      Properties.RequestedData('0'),
+      Properties.GPIPortNumber('0'),
+      Properties.GPOPortNumber('0')
     ]
   })
 );
@@ -95,8 +95,8 @@ export const setReaderConfig = () => (
     id: 0x99,
     type: constants.SET_READER_CONFIG,
     args: [
-      properties.Reserved(4),
-      properties.EventsAndReports('8')
+      Properties.Reserved(4),
+      Properties.EventsAndReports('8')
     ]
   })
 );

--- a/app/lib/LLRP/parameters.js
+++ b/app/lib/LLRP/parameters.js
@@ -1,6 +1,5 @@
-import * as properties from './properties';
+import Properties from './properties';
 import * as constants from './parameterConstants';
-
 
 export type propertyType = {
   name: string,
@@ -25,216 +24,217 @@ export type parameterType = {
 // =====================
 
 /**
- * initArgs
- *
- * Takes all the avaiable keys in values and runs functions on them
- * if they are listed in the array.
- *
- * @param {Object} values
- * @param {Array<function>} args
- */
+  * initArgs
+  *
+  * Takes all the avaiable keys in values and runs functions on them
+  * if they are listed in the array.
+  *
+  * @param {Object} values
+  * @param {Array<function>} args
+  */
 const initArgs = (values, args) => (
-  args.filter(arg => values[`${arg.name}`] !== undefined)
+  args.filter(arg => values[`${arg.name}`])
     .map(arg => arg(values[`${arg.name}`]))
 );
+export default class Parameters {
+  /**
+    * ROSpecStartTrigger
+    *
+    * @param {Object} values
+    * @returns {parameterType}
+    */
+  static ROSpecStartTrigger(values) {
+    return {
+      type: constants.ROSpecStartTrigger,
+      args: initArgs(values, [
+        Properties.ROSpecStartTriggerType,
+      ])
+    };
+  }
 
-/**
- * ROSpecStartTrigger
- *
- * @param {Object} values
- * @returns {parameterType}
- */
-export function ROSpecStartTrigger(values) {
-  return {
-    type: constants.ROSpecStartTrigger,
-    args: initArgs(values, [
-      properties.ROSpecStartTriggerType,
-    ])
-  };
-}
+  /**
+    * ROSpecStopTrigger
+    *
+    * @param {Object} values
+    * @returns {parameterType}
+    */
+  static ROSpecStopTrigger(values) {
+    return {
+      type: constants.ROSpecStopTrigger,
+      args: initArgs(values, [
+        Properties.ROSpecStopTriggerType,
+        Properties.DurationTriggerValue
+      ])
+    };
+  }
 
-/**
- * ROSpecStopTrigger
- *
- * @param {Object} values
- * @returns {parameterType}
- */
-export function ROSpecStopTrigger(values) {
-  return {
-    type: constants.ROSpecStopTrigger,
-    args: initArgs(values, [
-      properties.ROSpecStopTriggerType,
-      properties.DurationTriggerValue
-    ])
-  };
-}
+  /**
+    * ROBoundarySpec
+    *
+    * @param {Object} values
+    * @returns {parameterType}
+    */
+  static ROBoundarySpec(values) {
+    return {
+      type: constants.ROBoundarySpec,
+      args: initArgs(values, [
+        Parameters.ROSpecStartTrigger,
+        Parameters.ROSpecStopTrigger
+      ])
+    };
+  }
 
-/**
- * ROBoundarySpec
- *
- * @param {Object} values
- * @returns {parameterType}
- */
-export function ROBoundarySpec(values) {
-  return {
-    type: constants.ROBoundarySpec,
-    args: initArgs(values, [
-      ROSpecStartTrigger,
-      ROSpecStopTrigger
-    ])
-  };
-}
+  /**
+    * AISpecStopTrigger
+    *
+    * @param {Object} values
+    * @returns {parameterType}
+    */
+  static AISpecStopTrigger(values) {
+    return {
+      type: constants.AISpecStopTrigger,
+      args: initArgs(values, [
+        Properties.AISpecStopTriggerType,
+        Properties.DurationTriggerValue
+      ])
+    };
+  }
 
-/**
- * AISpecStopTrigger
- *
- * @param {Object} values
- * @returns {parameterType}
- */
-export function AISpecStopTrigger(values) {
-  return {
-    type: constants.AISpecStopTrigger,
-    args: initArgs(values, [
-      properties.AISpecStopTriggerType,
-      properties.DurationTriggerValue
-    ])
-  };
-}
+  /**
+    * InventoryParameterSpec
+    *
+    * @param {Object} values
+    * @returns {parameterType}
+    */
+  static InventoryParameterSpec(values) {
+    return {
+      type: constants.InventoryParameterSpec,
+      args: initArgs(values, [
+        Properties.InventoryParameterSpecID,
+        Properties.ProtocolID,
+      ])
+    };
+  }
 
-/**
- * InventoryParameterSpec
- *
- * @param {Object} values
- * @returns {parameterType}
- */
-export function InventoryParameterSpec(values) {
-  return {
-    type: constants.InventoryParameterSpec,
-    args: initArgs(values, [
-      properties.InventoryParameterSpecID,
-      properties.ProtocolID,
-    ])
-  };
-}
+  /**
+    * AISpec
+    *
+    * @param {Object} values
+    * @returns {parameterType}
+    */
+  static AISpec(values) {
+    return {
+      type: constants.AISpec,
+      args: initArgs(values, [
+        Properties.AntennaCount,
+        Properties.AntennaID,
+        Parameters.AISpecStopTrigger,
+        Parameters.InventoryParameterSpec
+        // AntennaConfigParam
+        // CustomParam
+      ])
+    };
+  }
 
-/**
- * AISpec
- *
- * @param {Object} values
- * @returns {parameterType}
- */
-export function AISpec(values) {
-  return {
-    type: constants.AISpec,
-    args: initArgs(values, [
-      properties.AntennaCount,
-      properties.AntennaID,
-      AISpecStopTrigger,
-      InventoryParameterSpec
-      // AntennaConfigParam
-      // CustomParam
-    ])
-  };
-}
+  /**
+    * TagReportContentSelector
+    *
+    * @param {Object} values
+    * @returns {parameterType}
+    */
+  static TagReportContentSelector(values) {
+    return {
+      type: constants.TagReportContentSelector,
+      args: initArgs(values, [
+        Properties.TagReportContentSelectorValue,
+        Parameters.C1G2EPCMemorySelector,
+      ])
+    };
+  }
 
-/**
- * TagReportContentSelector
- *
- * @param {Object} values
- * @returns {parameterType}
- */
-export function TagReportContentSelector(values) {
-  return {
-    type: constants.TagReportContentSelector,
-    args: initArgs(values, [
-      properties.TagReportContentSelectorValue,
-      C1G2EPCMemorySelector,
-    ])
-  };
-}
+  /**
+    * C1G2EPCMemorySelector
+    *
+    * @param {Object} values
+    * @returns {parameterType}
+    */
+  static C1G2EPCMemorySelector(values) {
+    return {
+      type: constants.C1G2EPCMemorySelector,
+      args: initArgs(values, [
+        Properties.C1G2EPCMemorySelectorValue
+      ])
+    };
+  }
 
-/**
- * C1G2EPCMemorySelector
- *
- * @param {Object} values
- * @returns {parameterType}
- */
-export function C1G2EPCMemorySelector(values) {
-  return {
-    type: constants.C1G2EPCMemorySelector,
-    args: initArgs(values, [
-      properties.C1G2EPCMemorySelectorValue
-    ])
-  };
-}
+  /**
+    * ROReportSpec
+    *
+    * @param {Object} values
+    * @returns {parameterType}
+    */
+  static ROReportSpec(values) {
+    return {
+      type: constants.ROReportSpec,
+      args: initArgs(values, [
+        Properties.ROReportTrigger,
+        Properties.ROReportTriggerNValue,
+        Parameters.TagReportContentSelector,
+        Parameters.Custom
+      ])
+    };
+  }
 
-/**
- * ROReportSpec
- *
- * @param {Object} values
- * @returns {parameterType}
- */
-export function ROReportSpec(values) {
-  return {
-    type: constants.ROReportSpec,
-    args: initArgs(values, [
-      properties.ROReportTrigger,
-      properties.ROReportTriggerNValue,
-      TagReportContentSelector,
-      Custom
-    ])
-  };
-}
-
-/**
- * ROSpec
- *
- * @param {Object} values
- * @returns {parameterType}
- */
-export function ROSpec(values) {
-  return {
-    type: constants.ROSpec,
-    args: initArgs(values, [
-      properties.ROSpecID,
-      properties.ROSpecPriority,
-      properties.ROSpecCurrentState,
-      ROBoundarySpec,
-      AISpec,
-      ROReportSpec
-    ])
-  };
-}
+  /**
+    * ROSpec
+    *
+    * @param {Object} values
+    * @returns {parameterType}
+    */
+  static ROSpec(values) {
+    return {
+      type: constants.ROSpec,
+      args: initArgs(values, [
+        Properties.ROSpecID,
+        Properties.ROSpecPriority,
+        Properties.ROSpecCurrentState,
+        Parameters.ROBoundarySpec,
+        Parameters.AISpec,
+        Parameters.ROReportSpec
+      ])
+    };
+  }
 
 
-/**
- * EventsAndReports
- *
- * @param {Object} values
- * @returns {parameterType}
- */
-export function EventsAndReports(values) {
-  return {
-    type: constants.EventsAndReports,
-    args: initArgs(values, [
-      properties.EventsAndReports
-    ])
-  };
-}
+  /**
+    * EventsAndReports
+    *
+    * @param {Object} values
+    * @returns {parameterType}
+    */
+  static EventsAndReports(values) {
+    return {
+      type: constants.EventsAndReports,
+      args: initArgs(values, [
+        Properties.EventsAndReports
+      ])
+    };
+  }
 
-/**
- * Custom
- *
- * @param {Object} values
- * @returns {parameterType}
- */
-export function Custom(values) {
-  return {
-    type: constants.Custom,
-    args: initArgs(values, [
-      properties.VendorID,
-      properties.Subtype,
-      properties.VendorParameterValue
-    ])
-  };
+  /**
+    * Custom
+    *
+    * @param {Object} values
+    * @returns {parameterType}
+    */
+  static Custom(values) {
+    return {
+      type: constants.Custom,
+      args: initArgs(values, [
+        Properties.VendorID,
+        Properties.Subtype,
+        Properties.VendorParameterValue
+      ])
+    };
+  }
 }

--- a/app/lib/LLRP/properties.js
+++ b/app/lib/LLRP/properties.js
@@ -69,170 +69,172 @@ const initProp = (value: string | Array<number> | null, base: string, length: nu
   }
 };
 
-/**
-  * Reserved
-  *
-  * Used for any reserved bits inside of a parameter
-  *
-  * @param {number} length
-  */
-export function Reserved(length) {
-  return {
-    name: 'Reserved',
-    ...initProp('0', 'hex', length)
-  };
-}
+export default class Properties {
+  /**
+    * Reserved
+    *
+    * Used for any reserved bits inside of a parameter
+    *
+    * @param {number} length
+    */
+  static Reserved(length) {
+    return {
+      name: 'Reserved',
+      ...initProp('0', 'hex', length)
+    };
+  }
 
-export function ROSpecCurrentState(value) {
-  return {
-    name: 'ROSpecCurrentState',
-    ...initProp(value, 'hex', 8)
-  };
-}
+  static ROSpecCurrentState(value) {
+    return {
+      name: 'ROSpecCurrentState',
+      ...initProp(value, 'hex', 8)
+    };
+  }
 
-export function ROSpecPriority(value) {
-  return {
-    name: 'ROSpecPriority',
-    ...initProp(value, 'hex', 8)
-  };
-}
+  static ROSpecPriority(value) {
+    return {
+      name: 'ROSpecPriority',
+      ...initProp(value, 'hex', 8)
+    };
+  }
 
-export function ROSpecID(value) {
-  return {
-    name: 'ROSpecID',
-    ...initProp(value, 'hex', 32)
-  };
-}
+  static ROSpecID(value) {
+    return {
+      name: 'ROSpecID',
+      ...initProp(value, 'hex', 32)
+    };
+  }
 
-export function ROSpecStartTriggerType(value) {
-  return {
-    name: 'ROSpecStartTriggerType',
-    ...initProp(value, 'hex', 8)
-  };
-}
+  static ROSpecStartTriggerType(value) {
+    return {
+      name: 'ROSpecStartTriggerType',
+      ...initProp(value, 'hex', 8)
+    };
+  }
 
-export function ROSpecStopTriggerType(value) {
-  return {
-    name: 'ROSpecStopTriggerType',
-    ...initProp(value, 'hex', 8)
-  };
-}
+  static ROSpecStopTriggerType(value) {
+    return {
+      name: 'ROSpecStopTriggerType',
+      ...initProp(value, 'hex', 8)
+    };
+  }
 
-export function DurationTriggerValue(value) {
-  return {
-    name: 'DurationTriggerValue',
-    ...initProp(value, 'hex', 32)
-  };
-}
+  static DurationTriggerValue(value) {
+    return {
+      name: 'DurationTriggerValue',
+      ...initProp(value, 'hex', 32)
+    };
+  }
 
-export function AntennaCount(value) {
-  return {
-    name: 'AntennaCount',
-    ...initProp(value, 'hex', 16)
-  };
-}
+  static AntennaCount(value) {
+    return {
+      name: 'AntennaCount',
+      ...initProp(value, 'hex', 16)
+    };
+  }
 
-export function AntennaID(value) {
-  return {
-    name: 'AntennaID',
-    ...initProp(value, 'hex', 16)
-  };
-}
+  static AntennaID(value) {
+    return {
+      name: 'AntennaID',
+      ...initProp(value, 'hex', 16)
+    };
+  }
 
-export function AISpecStopTriggerType(value) {
-  return {
-    name: 'AISpecStopTriggerType',
-    ...initProp(value, 'hex', 8)
-  };
-}
+  static AISpecStopTriggerType(value) {
+    return {
+      name: 'AISpecStopTriggerType',
+      ...initProp(value, 'hex', 8)
+    };
+  }
 
-export function InventoryParameterSpecID(value) {
-  return {
-    name: 'InventoryParameterSpecID',
-    ...initProp(value, 'hex', 16)
-  };
-}
+  static InventoryParameterSpecID(value) {
+    return {
+      name: 'InventoryParameterSpecID',
+      ...initProp(value, 'hex', 16)
+    };
+  }
 
-export function ProtocolID(value) {
-  return {
-    name: 'ProtocolID',
-    ...initProp(value, 'hex', 8)
-  };
-}
+  static ProtocolID(value) {
+    return {
+      name: 'ProtocolID',
+      ...initProp(value, 'hex', 8)
+    };
+  }
 
-export function ROReportTrigger(value) {
-  return {
-    name: 'ROReportTrigger',
-    ...initProp(value, 'hex', 8)
-  };
-}
+  static ROReportTrigger(value) {
+    return {
+      name: 'ROReportTrigger',
+      ...initProp(value, 'hex', 8)
+    };
+  }
 
-export function ROReportTriggerNValue(value) {
-  return {
-    name: 'ROReportTriggerNValue',
-    ...initProp(value, 'hex', 16)
-  };
-}
+  static ROReportTriggerNValue(value) {
+    return {
+      name: 'ROReportTriggerNValue',
+      ...initProp(value, 'hex', 16)
+    };
+  }
 
-export function TagReportContentSelectorValue(value) {
-  return {
-    name: 'TagReportContentSelectorValue',
-    ...initProp(value, 'hex', 16)
-  };
-}
+  static TagReportContentSelectorValue(value) {
+    return {
+      name: 'TagReportContentSelectorValue',
+      ...initProp(value, 'hex', 16)
+    };
+  }
 
-export function C1G2EPCMemorySelectorValue(value) {
-  return {
-    name: 'C1G2EPCMemorySelectorValue',
-    ...initProp(value, 'hex', 8)
-  };
-}
+  static C1G2EPCMemorySelectorValue(value) {
+    return {
+      name: 'C1G2EPCMemorySelectorValue',
+      ...initProp(value, 'hex', 8)
+    };
+  }
 
-export function GPIPortNumber(value) {
-  return {
-    name: 'GPIPortNumber',
-    ...initProp(value, 'hex', 16)
-  };
-}
+  static GPIPortNumber(value) {
+    return {
+      name: 'GPIPortNumber',
+      ...initProp(value, 'hex', 16)
+    };
+  }
 
-export function GPOPortNumber(value) {
-  return {
-    name: 'GPOPortNumber',
-    ...initProp(value, 'hex', 16)
-  };
-}
+  static GPOPortNumber(value) {
+    return {
+      name: 'GPOPortNumber',
+      ...initProp(value, 'hex', 16)
+    };
+  }
 
-export function RequestedData(value) {
-  return {
-    name: 'RequestedData',
-    ...initProp(value, 'hex', 8)
-  };
-}
+  static RequestedData(value) {
+    return {
+      name: 'RequestedData',
+      ...initProp(value, 'hex', 8)
+    };
+  }
 
-export function EventsAndReports(value) {
-  return {
-    name: 'EventsAndReports',
-    ...initProp(value, 'hex', 2)
-  };
-}
+  static EventsAndReports(value) {
+    return {
+      name: 'EventsAndReports',
+      ...initProp(value, 'hex', 2)
+    };
+  }
 
-export function VendorID(value) {
-  return {
-    name: 'VendorID',
-    ...initProp(value, 'hex', 32)
-  };
-}
+  static VendorID(value) {
+    return {
+      name: 'VendorID',
+      ...initProp(value, 'hex', 32)
+    };
+  }
 
-export function Subtype(value) {
-  return {
-    name: 'Subtype',
-    ...initProp(value, 'hex', 32)
-  };
-}
+  static Subtype(value) {
+    return {
+      name: 'Subtype',
+      ...initProp(value, 'hex', 32)
+    };
+  }
 
-export function VendorParameterValue(value) {
-  return {
-    name: 'VendorParameterValue',
-    ...initProp(value, 'hex', 8)
-  };
+  static VendorParameterValue(value) {
+    return {
+      name: 'VendorParameterValue',
+      ...initProp(value, 'hex', 8)
+    };
+  }
 }

--- a/app/lib/logger/index.js
+++ b/app/lib/logger/index.js
@@ -1,0 +1,61 @@
+import path from 'path';
+import moment from 'moment';
+import jetpack from 'fs-jetpack';
+import { addMessage } from '../../actions/status';
+
+const { app } = require('electron').remote;
+
+class Log {
+  store: null
+  dataFolder: ''
+  debugFileName: ''
+  configFileName: ''
+
+  constructor() {
+    this.dataFolder = 'AlienRunwayData';
+    this.configFileName = 'config.json';
+    this.debugFileName = 'debug.log';
+  }
+
+  dataPath() { return path.join(app.getPath('documents'), this.dataFolder); }
+
+  debugPath() { return path.join(this.dataPath(), this.debugFileName); }
+
+  configPath() { return path.join(this.dataPath(), this.configFileName); }
+
+  file(messages: string | Array<string>, fileName: string | Array<string> = '') {
+    const msg = Array.isArray(messages) ? messages.join('') : messages;
+    if (fileName) { this.toFilename(fileName, msg); } else { this.toDebug(msg); }
+  }
+
+  toFilename(fileName: string | Array<string>, msg: string) {
+    jetpack.appendAsync(path.join(this.dataPath(), fileName), `${msg}\r`);
+  }
+
+  toDebug(msg: string) {
+    jetpack.appendAsync(this.debugPath(), `[${moment()}]: ${msg}\r`);
+  }
+
+  info(...messages: string | Array<string>) {
+    this.write(0, messages);
+  }
+
+  hexInfo(...messages: string | Array<string>) {
+    this.write(0, messages);
+  }
+
+  error(...messages: string | Array<string>) {
+    this.write(1, messages);
+  }
+
+  write(code: number, messages: string | Array<string>) {
+    if (Array.isArray(messages)) {
+      this.store.dispatch(addMessage(messages.join(), code));
+    } else {
+      this.store.dispatch(addMessage(messages, code));
+    }
+  }
+}
+
+const log = new Log();
+export default log;

--- a/app/server/index.js
+++ b/app/server/index.js
@@ -199,7 +199,7 @@ export default class RfidRelay {
     const formattedArray = this.getFormattedReaderData(data, readerAddress);
     if (runScoreServerConnected) this.runScore.write(`${formattedArray.join(',')}\r`);
     log.file(
-      `${formattedArray.join(',')}\r`,
+      formattedArray.join(','),
       path.join(`${moment(startTime).format('YYYYMMDDhhmmss')}`, `${formattedArray[3] || 'unmappedEvent'}.csv`)
     );
   }
@@ -314,7 +314,7 @@ export default class RfidRelay {
         break;
       case 'START_ROSPEC_RESPONSE':
         // log.info(nameOf(message), read(parameters));
-        log.info(`LLRP Server ready!: ${conn.remoteAddress}:${conn.remotePort}`);
+        log.info(`LLRP Server ready on: ${conn.remoteAddress}:${conn.remotePort}`);
         break;
       case 'KEEPALIVE':
         // log.info(nameOf(message), read(parameters));

--- a/app/server/index.js
+++ b/app/server/index.js
@@ -1,45 +1,21 @@
 import net from 'net';
-import moment from 'moment';
 import path from 'path';
-import jetpack from 'fs-jetpack';
+import moment from 'moment';
 
-import { addMessage, setRSServerConnection } from '../actions/status';
+import { LLRP_TAG_REGEX, MAX_CONNECT_ATTEMPTS } from '../constants';
+import { setRSServerConnection } from '../actions/status';
 import * as llrpMessages from '../lib/LLRP/messages';
 import decode from '../lib/LLRP/decode';
+import log from '../lib/logger';
 
-const { app } = require('electron').remote;
-
-export const LLRP_TAG_REGEX = /(00f0000c00f100080010)((\d){4})/;
-export const MAX_CONNECT_ATTEMPTS = 5;
-export const LOCAL_FOLDER = 'AlienRunwayData';
-export const DOCUMENTS_PATH = app.getPath('documents');
-export const LOGS_PATH = `${DOCUMENTS_PATH}/${LOCAL_FOLDER}`;
-// TODO: It would be nice to have the structure of logging changes
-//        so that debug messages could be shown and/or not shown.
-export const log = {
-  store: null,
-  info(...messages: string | Array<string>) {
-    this.write(0, messages);
-  },
-  hexInfo(...messages: string | Array<string>) {
-    this.write(0, messages);
-  },
-  error(...messages: string | Array<string>) {
-    this.write(1, messages);
-  },
-  write(code: number, messages: string | Array<string>) {
-    if (Array.isArray(messages)) {
-      this.store.dispatch(addMessage(messages.join(), code));
-    } else {
-      this.store.dispatch(addMessage(messages, code));
-    }
-  }
-};
 
 // ===============
 // LLRP helper functions
 // ===============
 const nameOf = (obj) => Object.keys(obj)[0];
+const read = (obj) => (
+  parseInt(obj[0].LLRPStatus.value, 16) ? hexToText(obj[0].LLRPStatus.value) : 'Success!'
+); // eslint-disable-line
 const hexToText = (val: string) => {
   let str = '';
   for (let i = 0; i < val.length; i += 2) {
@@ -47,7 +23,6 @@ const hexToText = (val: string) => {
   }
   return str;
 };
-const read = (obj) => (parseInt(obj[0].LLRPStatus.value, 16) ? hexToText(obj[0].LLRPStatus.value) : 'Success!'); // eslint-disable-line
 const getTags = (str: string, reg: RegExp, ret: Array<string> = []) => {
   if (str.length < 1) { return undefined; }
   const arry = str.match(reg);
@@ -223,14 +198,9 @@ export default class RfidRelay {
     } = this.store.getState();
     const formattedArray = this.getFormattedReaderData(data, readerAddress);
     if (runScoreServerConnected) this.runScore.write(`${formattedArray.join(',')}\r`);
-
-    jetpack.appendAsync(
-      path.join(
-        LOGS_PATH,
-        moment(startTime).format('YYYYMMDDhhmmss'),
-        `${formattedArray[3] || 'unmappedEvent'}.csv`
-      ),
-      `${formattedArray.join(',')}\r`
+    log.file(
+      `${formattedArray.join(',')}\r`,
+      path.join(`${moment(startTime).format('YYYYMMDDhhmmss')}`, `${formattedArray[3] || 'unmappedEvent'}.csv`)
     );
   }
 


### PR DESCRIPTION
This PR addresses the following issue:
 - ADD_ROSPEC message now generates correctly
> The way that the function worked to create the string, it was using the names of functions to compare with the values passed in. This worked in development due to sourcemapping, but because production was munging the data the function names were being lost. To prevent this from happening, we wrapped the parameters and properties in a class.

This PR has the following quality of life changes:
 - Log is now in it's own file & class
> Previously, logging was only done on the server. It is now a class in the lib that can write to the status messages and perform file writes.